### PR TITLE
Add Name/Address metadata back after Stripe update

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
@@ -29,7 +29,7 @@
     };
 
     function createToken() {
-      stripe.createToken(card).then((result) => {
+      stripe.createToken(card, Spree.stripeAdditionalInfo).then((result) => {
         if (result.error) {
           // Inform the user if there was an error
           const errorElement = document.getElementById('card-errors');


### PR DESCRIPTION
TrackerUrl: https://www.pivotaltracker.com/story/show/175383754

Missing owner details (current buggy behavior):
<img width="1121" alt="Screen Shot 2021-01-14 at 4 15 55 PM" src="https://user-images.githubusercontent.com/332635/104655819-e6558180-5683-11eb-896f-9b398599a5d2.png">

Owner populated (new behavior):
<img width="1115" alt="Screen Shot 2021-01-14 at 4 16 08 PM" src="https://user-images.githubusercontent.com/332635/104655869-f8cfbb00-5683-11eb-8bac-3e6cfb91a439.png">
