### PR TITLE
Canceling a Merch::Order results in a "whoops page" when the Merch Store is using Stripe/Authorize.net

### DIFF
--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -64,6 +64,13 @@ module Spree
       response
     end
 
+    def try_void(payment)
+      void_response = void(payment.response_code, payment.source, {})
+      return void_response if void_response.success?
+
+      false
+    end
+
     def payment_profiles_supported?
       true
     end

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -51,6 +51,13 @@ module Spree
       gateway.void(response_code, {})
     end
 
+    def try_void(payment)
+      void_response = void(payment.response_code, payment.source, {})
+      return void_response if void_response.success?
+
+      false
+    end
+
     def create_profile(payment)
       return unless payment.source.gateway_customer_profile_id.nil?
 


### PR DESCRIPTION
TrackerUrl: https://www.pivotaltracker.com/story/show/177569316